### PR TITLE
CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+machine:
+    node:
+        version: node
+    pre:
+        - mkdir ~/.yarn-cache
+dependencies:
+    pre:
+        - 'curl -o- -L https://yarnpkg.com/install.sh | bash'
+    cache_directories:
+        - ~/.yarn-cache
+    override:
+        - yarn install
+test:
+    override:
+        - yarn test
+    pre:
+        - npm run lint
+    post:
+        - npm run build
+general:
+    artifacts:
+        - build

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ test:
     pre:
         - npm run lint
     post:
+        - >
+          jq '. + {homepage: "https://__something__.circle-artifacts.com/0/home/ubuntu/babel-repl/build/"}' package.json > package.ci.json
+          && mv -f package.ci.json package.json
         - npm run build
 general:
     artifacts:

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,19 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
-it("renders without crashing", () => {
-  const div = document.createElement("div");
-  ReactDOM.render(<App />, div);
+describe("App", () => {
+  let div;
+
+  beforeEach(() => {
+    div = document.createElement("div");
+    document.body.appendChild(div);
+  });
+
+  it("renders without crashing", () => {
+    ReactDOM.render(<App />, div);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(div);
+  });
 });


### PR DESCRIPTION
(The second in my series of _exciting! infrastructure! PRs!_)

This gets the basic `create-react-app`-generated test to actually work in the presence of `react-ace`, and contains a build configuration for CircleCI.

I picked CircleCI for their excellent artifacts support, which can serve artifacts from e.g. the latest successful build on a branch with URLs like: [https://circleci.com/api/v1/project/**motiz88**/babel-repl/latest/artifacts/0//home/ubuntu/babel-repl/build/index.html?**branch=ci**&filter=successful](https://circleci.com/api/v1/project/motiz88/babel-repl/latest/artifacts/0//home/ubuntu/babel-repl/build/index.html?branch=ci&filter=successful). So after merging you can put this link (with obvious changes) in the README as a quick way of serving the latest and greatest.
